### PR TITLE
Comms and Verbose refix

### DIFF
--- a/serialOM.py
+++ b/serialOM.py
@@ -223,6 +223,8 @@ class serialOM:
                 # Verbose output replaces the existing key if a result is supplied
                 if payload['result'] != None:
                     self.model[payload['key']] = payload['result']
+                    if payload['key'] in self._seqKeys:
+                        self._seqs[payload['key']] = self.model['seqs'][payload['key']]
                     success = True
         return success
 
@@ -232,8 +234,6 @@ class serialOM:
         if key in verboseList:
             #debug print('*',end='')
             if not self._omRequest(key,'vnd' + str(self._depth)):
-                # failed verbose key, reset seq
-                self._seqs[key] = -1
                 return False;
         else:
             #debug print('.',end='')
@@ -275,7 +275,6 @@ class serialOM:
             for key in self._seqKeys:
                 if self._seqs[key] != self.model['seqs'][key]:
                     changed.append(key)
-                    self._seqs[key] = self.model['seqs'][key]
         else:
             self._print('sequence key request failed')
         return changed

--- a/serialOM.py
+++ b/serialOM.py
@@ -320,10 +320,12 @@ class serialOM:
                 rawLine = self._rrf.readline()
             except Exception as e:
                 raise serialOMError('Serial read from controller failed : ' + repr(e)) from None
+            if not rawLine:
+                return ''
             try:
                 readLine = rawLine.decode('ascii')
             except:
-                self_print('ascii decode failure')
+                self._print('ascii decode failure')
                 readLine = ''
             if self._rawLog and readLine:
                 self._rawLog.write(readLine)

--- a/serialOM.py
+++ b/serialOM.py
@@ -203,6 +203,9 @@ class serialOM:
                 self._print('invalid JSON recieved')
                 continue
             # Update local OM data
+            if 'seq' in payload.keys():
+                # json info messages, currently ignored, string in payload['resp']
+                continue
             if 'key' not in payload.keys():
                 self._print('valid JSON recieved, but no "key" data in it')
                 continue


### PR DESCRIPTION
Some changes to make things more robust:
* Modified comms response loop to be more aggressive in gathering data after a send, and better at handling multi-line and out-of-sequence responses that can occur when the controller is slow or info messages etc are output.
* Verbose request handling is now more 'direct', with no passing a 'verboseList' around at a high level.
   We decide whether to use a verbose request at the moment we send it, and only record the updated sequence when we get a valid verbose response for the key.

The above address potential out of sequence issues and missed responses in a more robust manner; closer to my original design goals (which became compromised in implementation)